### PR TITLE
add new step for delete '=' in fenced codes

### DIFF
--- a/build
+++ b/build
@@ -58,7 +58,7 @@ rsync -avh stevie-king/ docs/publishing/
 
 echo ""
 echo "${blue}[+] Delete '=' in fenced codes with line numbers...$normal"
-grep -lrE "\`\`\`\w*=" ./docs/posts | xargs sed -i '' -r "s/(\`\`\`[a-zA-Z0-9]+)=/\1/g"
+grep -lrE "\`\`\`\w*=" ./docs/posts | xargs sed -i -r "s/(\`\`\`[a-zA-Z0-9]+)=/\1/g"
 
 kill %1 > /dev/null
 echo ""

--- a/build
+++ b/build
@@ -56,6 +56,10 @@ echo ""
 echo "${blue}[+] Including stevie king to docs/...$normal"
 rsync -avh stevie-king/ docs/publishing/
 
+echo ""
+echo "${blue}[+] Delete '=' in fenced codes with line numbers...$normal"
+grep -lrE "\`\`\`\w*=" ./docs/posts | xargs sed -i '' -r "s/(\`\`\`[a-zA-Z0-9]+)=/\1/g"
+
 kill %1 > /dev/null
 echo ""
 echo "${green}[√] Build of static site to docs/ complete.$normal"


### PR DESCRIPTION
 This allows to use the library highlight.js for highlight code
 - The symbol "="  allows code with line number in hedgedoc
 - The symbol "=" is not recognized by highlight.js

The change is made over blog's html files 

For example:

**Before**
```
```javascript=
.....
```

**After**
```
```javascript
.....
```