### PR TITLE
fix duplicate metatags being added from both base and post template

### DIFF
--- a/content.json
+++ b/content.json
@@ -1,5 +1,8 @@
 {
   "SITE_TITLE": "Monadical Consulting",
+  "SITE_DESCRIPTION":"Monadical is a full-stack software development consultancy. We specialize in full-stack web development and custom software solutions.",
+  "SITE_IMG":"https://monadical.com/static/core/img/og.jpg",
+  "SITE_TYPE":"website",
   "SITE_DOMAIN": "monadical.com",
   "PAGES": {
     "index": {

--- a/templates/about.html
+++ b/templates/about.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}About{% endblock %}
+{% block title %}About | Monadical Consulting{% endblock %}
 {% block subtitle %}About{% endblock %}
 {% block enableLogo %}enable-logo{% endblock %}
 {% block article %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -3,28 +3,29 @@
 
 <head>
 
-    <title>{% block title %}Home{% endblock %} | {{SITE_TITLE}}</title>
+    <title>{% block title %}Title{% endblock %}</title>
 
     <!-- Meta Tags Start -->
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="title" content="{{ self.title() }} | {{SITE_TITLE}}">
+    <meta name="title" content="{{ self.title() }}">
     <meta name="description"
-        content="Monadical is a full-stack software development consultancy. We specialize in full-stack web development and custom software solutions.">
+        content="{% block description %}{{description}}{{SITE_DESCRIPTION}}{% endblock %}">
     <meta property="og:locale" content="en_US" />
     <meta property="og:description"
-        content="Monadical is a full-stack software development consultancy. We specialize in full-stack web development and custom software solutions.">
-    <meta property="og:image" content="https://monadical.com/static/core/img/og.jpg">
-    <meta property="og:title" content="{{ self.title() }} | {{SITE_TITLE}}">
-    <meta property="og:type" content="website">
+        content="{{ self.description() or SITE_DESCRIPTION }}">
+    <meta property="og:image" name="image" content="{% block img %}{{img}}{{SITE_IMG}}{% endblock %}">
+    <meta property="og:title" content="{{ self.title() }}">
+    <meta property="og:type" content="{% block type %}{{type}}{{SITE_TYPE}}{% endblock %}">
     <meta property="og:url" content=https://{{SITE_DOMAIN}}{{request.path}} />
+    <meta property="og:site_name" content="{{SITE_TITLE}}" />
     
     <meta property="twitter:card" content="summary_large_image">
     <meta property="twitter:description"
-        content="Monadical is a full-stack software development consultancy. We specialize in full-stack web development and custom software solutions.">
-    <meta property="twitter:image" content="https://monadical.com/static/core/img/og.jpg">
+        content="{{ self.description() or SITE_DESCRIPTION }}">
+    <meta property="twitter:image" content="{{ self.img() or SITE_IMG }}">
     <meta property="twitter:site" content="@MonadicalHQ">
-    <meta property="twitter:title" content="{{ self.title() }} | {{SITE_TITLE}}">
+    <meta property="twitter:title" content="{{ self.title() }}">
     <meta property="twitter:url" content=https://{{SITE_DOMAIN}}{{request.path}} />
     <meta name="msapplication-TileColor" content="#da532c">
     <meta name="theme-color" content="#ffffff">

--- a/templates/blog.html
+++ b/templates/blog.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Posts &amp; Articles{% endblock %}
+{% block title %}Posts &amp; Articles | Monadical Consulting{% endblock %}
 {% block subtitle %}Blog{% endblock %}
 {% block enableLogo %}enable-logo{% endblock %}
 

--- a/templates/contact-us.html
+++ b/templates/contact-us.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %} 
-{% block title %}Contact us{% endblock %} 
+{% block title %}Contact us | Monadical Consulting{% endblock %}
 {% block subtitle %}Contact us{% endblock %} 
 {% block enableLogo %}enable-logo{% endblock %} 
 {% block head %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Home{% endblock %}
+{% block title %}Home | Monadical Consulting{% endblock %}
 {% block subtitle %}Home{% endblock %}
 {% block enableLogo %}enable-logo{% endblock %}
 

--- a/templates/portfolio.html
+++ b/templates/portfolio.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %} 
-{% block title %}Portfolio{% endblock %}
+{% block title %}Portfolio | Monadical Consulting{% endblock %}
 {% block subtitle %}Portfolio{% endblock %} 
 {% block enableLogo %}enable-logo{% endblock %} 
 {% block head %}

--- a/templates/post.html
+++ b/templates/post.html
@@ -1,29 +1,16 @@
 {% extends "base.html" %}
 
 {% block title %}{{title}}{% endblock %}
+{% block description %}{{description}}{% endblock %}
+{% block type %}article{% endblock %}
+{% block img %}https://{{SITE_DOMAIN}}{{img}}{% endblock %}
 {% block subtitle %}<a href="{{PAGES.blog.url}}">Blog</a>{% endblock %}
 {% block enableLogo %}enable-logo{% endblock %}
 
 {% block head %}
 <link rel="stylesheet" href="/static/core/css/index.css">
-<meta name="description" content="{{description}}" />
 
-<!-- Required Open Graph data -->
-<meta property="og:title" content="{{title}}" />
-<meta property="og:type" content="article" />
-<meta property="og:image" content="https://{{SITE_DOMAIN}}{{img}}" />
-<meta property="og:url" content="https://{{SITE_DOMAIN}}{{url}}" />
-<!-- Optional Open Graph data -->
-<meta property="og:description" content="{{description}}" />
-<meta property="og:site_name" content="{{SITE_TITLE}}" />
-<meta property="og:locale" content="en_US" />
-<!-- Find additional markup on https://ogp.me -->
-<!-- Twitter Card data -->
-<meta name="twitter:card" content="summary">
-<meta name="twitter:site" content="@MonadicalHQ">
-<meta name="twitter:title" content="{{title}}">
-<meta name="twitter:description" content="{{description}}">
-<meta name="twitter:image" content="https://{{SITE_DOMAIN}}{{img}}">
+
 {% endblock %}
 
 {% block article %}

--- a/templates/projects.html
+++ b/templates/projects.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Projects{% endblock %}
+{% block title %}Projects | Monadical Consulting{% endblock %}
 {% block subtitle %}Projects{% endblock %}
 {% block article %}
 <div class="container-full cases-home">

--- a/templates/sales.html
+++ b/templates/sales.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Home{% endblock %}
+{% block title %}Sales | Monadical Consulting{% endblock %}
 {% block subtitle %}Home{% endblock %}
 {% block enableLogo %}enable-logo{% endblock %}
 

--- a/templates/services.html
+++ b/templates/services.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Home{% endblock %}
+{% block title %}Services | Monadical Consulting{% endblock %}
 {% block subtitle %}Home{% endblock %}
 {% block enableLogo %}enable-logo{% endblock %}
 

--- a/templates/team.html
+++ b/templates/team.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Team{% endblock %}
+{% block title %}Team | Monadical Consulting{% endblock %}
 {% block subtitle %}Team{% endblock %}
 {% block enableLogo %}enable-logo{% endblock %}
 


### PR DESCRIPTION
before:

![screenshot 2022-08-24 at 21 07 15@2x](https://user-images.githubusercontent.com/7106086/186426449-8a3c09b1-f176-4b31-917b-8141c1f487ce.png)

after:
![screenshot 2022-08-24 at 21 08 30@2x](https://user-images.githubusercontent.com/7106086/186426548-e89129f7-571b-4e97-a86b-b0450cbe18a9.png)


note: I'll verify on sites like LinkedIn, twitter etc after deployment and post results. 

note 2: there's one more existing bug where meta tags are being added inside `<article>` section as well. I tried fixing it but couldn't get it to work. I'll create a new issue to track this bug. Let me know if anyone else know how to fix it.

![screenshot 2022-08-24 at 21 11 15@2x](https://user-images.githubusercontent.com/7106086/186427139-3f2fc26b-3ff3-4efc-bf98-f9105ce13ef1.png)
