### PR TITLE
add tag to async/await article

### DIFF
--- a/content.json
+++ b/content.json
@@ -76,11 +76,7 @@
         "async",
         "await",
         "python",
-        "javascript",
-        "asyncio",
-        "event_loop",
-        "asyncelasticsearch",
-        "asynchronous"
+        "javascript"
       ],
       "length": "31 min read",
       "source": "https://docs.monadical.com/s/python-vs-javascript-dealing-with-the-quirks-of-async-await",

--- a/content.json
+++ b/content.json
@@ -72,7 +72,16 @@
       "description": "As someone who’s used to implementing asynchronous programming in JS, implementing it in Python came as a surprise. Here’s what I learned.",
       "date": "2022-08-22",
       "img": "/static/python-vs-javascript-dealing-with-the-quirks-of-async-await.jpg",
-      "tags": [],
+      "tags": [
+        "async",
+        "await",
+        "python",
+        "javascript",
+        "asyncio",
+        "event_loop",
+        "asyncelasticsearch",
+        "asynchronous"
+      ],
       "length": "31 min read",
       "source": "https://docs.monadical.com/s/python-vs-javascript-dealing-with-the-quirks-of-async-await",
       "url": "/posts/python-vs-javascript-dealing-with-the-quirks-of-async-await.html",


### PR DESCRIPTION
Tag did not reflect after article was published, mostly due to how it was added. This PR adds it manually.


<img width="1244" alt="Screenshot 2022-08-29 at 14 26 20" src="https://user-images.githubusercontent.com/26967919/187211943-fc500a12-9681-4025-82b9-43abcc6f3767.png">
