### PR TITLE
feat: html standard anchors behaviour

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -267,8 +267,10 @@
             return "#\\" + reference.codePointAt(1).toString(16) + " " + reference.slice(2)
         }
         function smoothScroll(e) {
-            e.preventDefault();
-            e.stopPropagation();
+            const hash = decodeURIComponent(this.hash)
+            e.preventDefault()
+            e.stopPropagation()
+
             console.log('Scrolling to', this.getAttribute('href'))
             let reference = this.getAttribute('href')
             if (reference.match(/^#[0-9]+/)) {
@@ -277,9 +279,18 @@
             document.querySelector(reference).scrollIntoView({
                 behavior: 'smooth'
             });
+            setTimeout(() => {
+                window.location.hash = hash
+            }, 500/*arbitrary value, not standartized*/);
         }
         document.addEventListener('DOMContentLoaded', () => {
             document.querySelectorAll('a[smoothhashscroll]').forEach(elem => {
+                /*
+                   this code drops all the event listeners that were attached so far;
+                   we need to do it here because the event listeners themselves are not under control of this repo
+                   this content together with js files (that are executed) is presumably downloaded from hedgedoc
+                   this is a very hacky hack, we shall negate it "as soon as we can"
+                */
                 elem.parentNode.outerHTML = elem.parentNode.outerHTML
             })
             document.querySelectorAll('a[href^="#"], a[smoothhashscroll]').forEach(anchor => {


### PR DESCRIPTION
- .preventDefault() prevents the anchor from adding its hash to the address string
- which is done programmatically here
- 500ms is an arbitrary value; there's no callback the browser apis provide; big brain solution is to write own heuristics of "when the animation ended"
- therefore setTimeout 500 is deemed "good enough" for the purpose, being non-obstructive 
- additionally, researched the origins of magical `elem.parentNode.outerHTML = elem.parentNode.outerHTML` code and documented it

Business value is people reading articles see our anchors are up to HTML standards and trust our technical skills more.

It's also convenient when people want to share links to specific paragraphs.

Before: https://www.youtube.com/watch?v=yvmjwA7Id2k

After: https://www.youtube.com/watch?v=gqRqC3NQ3-Q
