### PR TITLE
Add meta nofollow, noindex to rate template

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -29,7 +29,6 @@
     <meta property="twitter:url" content=https://{{SITE_DOMAIN}}{{request.path}} />
     <meta name="msapplication-TileColor" content="#da532c">
     <meta name="theme-color" content="#ffffff">
-    <meta name="robots" content="follow, index" />
     <!-- Meta Tags End -->
 
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans|Ubuntu" type="text/css">

--- a/templates/rate.html
+++ b/templates/rate.html
@@ -23,6 +23,7 @@
 <meta name="twitter:title" content="{{title}}">
 <meta name="twitter:description" content="{{description}}">
 <meta name="twitter:image" content="https://{{SITE_DOMAIN}}{{img}}">
+<meta name="robots" content="nofollow, noindex" />
 {% endblock %}
 
 {% block article %}


### PR DESCRIPTION
This will prevent the pricing model pages from being indexed by search engines.

This also removes the meta "index, follow" option from the base template since it would conflict otherwise, and that setting is the default anyway (source: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name).

cc @curibe @juanArias8 @ATSiem @tessipedia 