### PR TITLE
Handle empty dicts to fix broken build

### DIFF
--- a/build
+++ b/build
@@ -44,9 +44,9 @@ cp static/robots.txt docs/robots.txt
 
 echo ""
 echo "${blue}[+] Saving pages as static HTML to output/...$normal"
-(cd docs; wget -q $(<pages.txt))
-(cd docs/posts; wget -q $(<../posts.txt))
-(cd docs; wget -q $(<rates.txt))
+(cd docs; [ -s pages.txt ] && wget -q $(<pages.txt))
+(cd docs/posts; [ -s ../posts.txt ] && wget -q $(<../posts.txt))
+(cd docs; [ -s rates.txt ] && wget -q $(<rates.txt))
 
 echo ""
 echo "${blue}[+] Saving rss feed as static XML to output/...$normal"

--- a/server
+++ b/server
@@ -147,13 +147,16 @@ def render_case(path):
 if __name__ == '__main__':
     if len(sys.argv) > 1 and sys.argv[1] == '--pages':
         # just print list of page urls
-        print('\n'.join(HOST + url for url in PAGES.keys()))
+        if len(PAGES) > 0:
+            print('\n'.join(HOST + url for url in PAGES.keys()))
     elif len(sys.argv) > 1 and sys.argv[1] == '--posts':
         # just print list of post urls
-        print('\n'.join(HOST + url for url in POSTS.keys()))
+        if len(POSTS) > 0:
+            print('\n'.join(HOST + url for url in POSTS.keys()))
     elif len(sys.argv) > 1 and sys.argv[1] == '--rates':
         # just print list of post urls
-        print('\n'.join(HOST + url for url in RATES.keys()))
+        if len(RATES) > 0:
+            print('\n'.join(HOST + url for url in RATES.keys()))
     else:
         # run the flask http server
         app.run()


### PR DESCRIPTION
The previous change made the RATES dict empty, which broke the build because it caused wget to be called with an empty command line. This adds a check for empty files and skips the wget call in that case.

cc @andreasbonini @juanarias8 @atsiem @cowpig