### PR TITLE
Add microsoft partner verification file

### DIFF
--- a/build
+++ b/build
@@ -35,6 +35,7 @@ mkdir -p docs/posts
 
 
 cp -r static docs/static
+cp -r static/.well-known docs/.well-known
 cp CNAME docs/CNAME
 cp static/favicon.ico docs/favicon.ico
 cp static/robots.txt docs/robots.txt

--- a/static/.well-known/microsoft-identity-association.json
+++ b/static/.well-known/microsoft-identity-association.json
@@ -1,0 +1,7 @@
+{
+  "associatedApplications": [
+    {
+      "applicationId": "3f8dd959-fd2d-4c34-a4e6-6b04b89ca472"
+    }
+  ]
+}


### PR DESCRIPTION
Add a file necessary to complete the microsoft partner verification process for skingenerator.io.

This is necessary because our employee email addresses end in @monadical.com and so therefore we must also verify the monadical.com domain, even though the app exists at skingenerator.io.

cc @cspencer @trandromeda @afreydev @tessipedia 