### PR TITLE
Include .well-known dir in jekyll config

### DIFF
--- a/build
+++ b/build
@@ -39,6 +39,7 @@ cp -r static/.well-known docs/.well-known
 cp CNAME docs/CNAME
 cp static/favicon.ico docs/favicon.ico
 cp static/robots.txt docs/robots.txt
+cp static/_config.yml docs/_config.yml
 ./server --pages > docs/pages.txt
 ./server --posts > docs/posts.txt
 ./server --rates > docs/rates.txt

--- a/static/_config.yml
+++ b/static/_config.yml
@@ -1,0 +1,2 @@
+include:
+  - ".well-known"


### PR DESCRIPTION
This is required to make the previous PR #269 work properly according to here: https://stackoverflow.com/questions/55880919/how-to-add-well-known-on-github-pages-files-using-html

cc @juanArias8 