### PR TITLE
fix URL of blog post "zulip bots part 3"

### DIFF
--- a/content.json
+++ b/content.json
@@ -126,7 +126,7 @@
         }
       ]
     },
-    "the-ai-evolution:-transforming-zulip-bots,-part-3": {
+    "the-ai-evolution-transforming-zulip-bots-part-3": {
       "title": "The AI Evolution: Transforming Zulip Bots, Part 3",
       "description": "Discover how AI reshapes chat automation in Zulip bots",
       "date": "2024-01-31",
@@ -141,8 +141,8 @@
       ],
       "length": "30 min read",
       "source": "https://docs.monadical.com/s/zulip-ai-bot-3",
-      "url": "/posts/the-ai-evolution:-transforming-zulip-bots,-part-3.html",
-      "template": "posts/the-ai-evolution:-transforming-zulip-bots,-part-3.html",
+      "url": "/posts/the-ai-evolution-transforming-zulip-bots-part-3.html",
+      "template": "posts/the-ai-evolution-transforming-zulip-bots-part-3.html",
       "authors": [
         {
           "name": "Juan David Arias",


### PR DESCRIPTION
Change from `the-ai-evolution:-transforming-zulip-bots,-part-3` to `the-ai-evolution-transforming-zulip-bots-part-3`

Before merging this PR we should coordinate with the ops team to update the URLs shared on social media: Instagram, twitter, facebook, etc.